### PR TITLE
Must return io.EOF to allow io.Copy to function correctly

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -159,6 +159,10 @@ func (r *Reader) skipPadding(mod int64) error {
 }
 
 func (r *Reader) Read(b []byte) (n int, e error) {
+	if r.remaining_bytes == 0 {
+		return 0, io.EOF
+	}
+
 	if len(b) > r.remaining_bytes {
 		b = b[0:r.remaining_bytes]
 	}


### PR DESCRIPTION
When using io.Copy, a call to `Read(b []byte)` must return `io.EOF` when reaching the end of the file. Without this change, io.Copy loops forever reading 0 bytes.
